### PR TITLE
* heap.c (create_heap): Initialize h->head->prev_level

### DIFF
--- a/heap.c
+++ b/heap.c
@@ -12,6 +12,7 @@ Heap* create_heap(){
     h->head->data_array = calloc(1, sizeof(int));
     if (h->head->data_array == NULL) exit(-1);
     h->head->next_level = NULL;
+    h->head->prev_level = NULL;
     
     //sets heap data
     h->insert_level = h->head;


### PR DESCRIPTION
Seen when  compiling with the flag `-fsanitize=address`:**
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==6414==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x000000401972 bp 0x7fff9e8c8980 sp 0x7fff9e8c8950 T0)
==6414==The signal is caused by a READ memory access.
==6414==Hint: this fault was caused by a dereference of a high value address (see register values below).  Dissassemble the provided pc to learn which register was used.
```